### PR TITLE
Make inert for Ember 3.22.0-alpha.1 and higher.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,15 @@ ember-cache-primitive-polyfill
 
 Polyfills Ember's [cache primitive API](https://github.com/emberjs/rfcs/blob/master/text/0615-autotracking-memoization.md).
 
-```js
-import {
-  createCache,
-  getValue,
-  isConst
-} from '@glimmer/tracking/primitives/cache';
-```
+> Provides a low-level primitive for memoizing the result of a function based
+> on autotracking, allowing users to create their own reactive systems that can
+> respond to changes in autotracked state.
 
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.13 or above
+* Ember.js v3.13 or above (inert for Ember 3.22+)
+* `ember-cli-babel` v7.22.1 or above
 * Ember CLI v3.8 or above
 * Node.js v10 or above
 
@@ -26,6 +23,41 @@ Installation
 ember install ember-cache-primitive-polyfill
 ```
 
+Usage
+------------------------------------------------------------------------------
+
+```js
+import { tracked } from '@glimmer/tracking';
+import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
+
+let computeCount = 0;
+
+class Person {
+  @tracked firstName = 'Jen';
+  @tracked lastName = 'Weber';
+
+  #fullName = createCache(() => {
+    ++computeCount;
+    return `${this.firstName} ${this.lastName}`;
+  })
+
+  get fullName() {
+    return getValue(this.#fullName);
+  }
+}
+
+let person = new Person();
+
+console.log(person.fullName); // Jen Weber
+console.log(count); // 1;
+console.log(person.fullName); // Jen Weber
+console.log(count); // 1;
+
+person.firstName = 'Jennifer';
+
+console.log(person.fullName); // Jennifer Weber
+console.log(count); // 2;
+```
 
 Contributing
 ------------------------------------------------------------------------------

--- a/index.js
+++ b/index.js
@@ -1,12 +1,26 @@
 'use strict';
 
+const VersionChecker = require('ember-cli-version-checker');
+const NATIVE_SUPPORT_VERSION = '3.22.0-alpha.1';
+let hasBeenWarned = false;
+
 module.exports = {
   name: require('./package').name,
 
   included() {
     this._super.included.apply(this, arguments);
 
-    this.import('vendor/ember-cache-primitive-polyfill.js');
+    const checker = new VersionChecker(this);
+    const emberVersion = checker.for('ember-source');
+
+    if (emberVersion.lt(NATIVE_SUPPORT_VERSION)) {
+      this.import('vendor/ember-cache-primitive-polyfill.js');
+    } else if (this.parent === this.project && !hasBeenWarned) {
+      this.ui.writeWarnLine(
+        `${this.name} is not required for Ember ${NATIVE_SUPPORT_VERSION} and later, please remove from your 'package.json'.`
+      );
+      hasBeenWarned = true;
+    }
   },
 
   treeForVendor(rawVendorTree) {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.22.1",
+    "ember-cli-version-checker": "^5.1.1",
     "ember-compatibility-helpers": "^1.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This feature is now enabled by default in Ember 3.22, this ensures that the polyfill does not run in those versions.